### PR TITLE
Geo Location Logic Added

### DIFF
--- a/backend/geolocation/IP2Location.js
+++ b/backend/geolocation/IP2Location.js
@@ -27,7 +27,19 @@ module.exports.ipLoc = function (IP) {
         {
             //START:TODO - GeoLocation Logic to Implement
 
-            
+           //Find the geolocation using the IP input from the local file, and return ip, country and city
+              result = ip2location.getAll(IP);
+                returnObj = {
+                    ip: result.ip,
+                    country: result.country_long,
+                    city: result.city
+                };
+            // Log debug information
+            if (debug) {
+                console.log(`${_func}: returnObj -> ${JSON.stringify(returnObj)}`);
+            }
+             // Return the object
+            return returnObj;
             //END:TODO
         }        
 

--- a/frontend/src/http-common.js
+++ b/frontend/src/http-common.js
@@ -1,11 +1,11 @@
 import axios from "axios";
 
 export default axios.create({
-  baseURL: "https://shiny-acorn-v64jvpv96xwhp9g4-8080.app.github.dev/api",
+  baseURL: "https://reimagined-spoon-r764w77jx44hx6q7-8080.app.github.dev/api",
   //baseURL: "https://action-codespace-wr6q7v7p7qgf5q79-8080.app.github.dev/api",
   headers: {
     "Content-type": "application/json",
-    //"x-forwarded-for-ip": "200.20.0.88", // Rio De Janeiro
+    "x-forwarded-for-ip": "200.20.0.88", // Rio De Janeiro
     //"x-forwarded-for-ip": "2.152.105.111" // Barcelona
     //"x-forwarded-for-ip": "8.210.96.219" // Hong Kong
     //"x-forwarded-for-ip": "78.135.85.96" // Beyoglu, Turkey


### PR DESCRIPTION
This pull request includes changes to both the frontend and backend of the application. The most important changes include updating the `baseURL` in `frontend/src/http-common.js` and adding geolocation logic to `IP2Location.js` in the backend.

Frontend changes:

* <a href="diffhunk://#diff-417f408634a0fd56c1e04afe5e9e049d17a96c4c50d80080b876391d360c1522L4-R8">`frontend/src/http-common.js`</a>: Updated the `baseURL` and added a comment with a Rio De Janeiro IP address for testing purposes.

Backend changes:

* <a href="diffhunk://#diff-b666da66309dc5519210deb4088b0299f26a8c04fff3c7acdb1b7c3e351bf384L30-R42">`backend/geolocation/IP2Location.js`</a>: Added geolocation logic to `IP2Location.js` using `ip2location` library to find geolocation using IP input, and returns IP, country, and city. Also logs debug information.